### PR TITLE
Refactor/user payload type

### DIFF
--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -1,12 +1,8 @@
-import {
-  CanActivate,
-  ExecutionContext,
-  Injectable,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { Request } from 'express';
+import { JwtPayload } from './auth.types';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
@@ -20,7 +16,7 @@ export class AuthGuard implements CanActivate {
     }
 
     try {
-      const payload = await this.jwtService.verifyAsync(token, {
+      const payload = await this.jwtService.verifyAsync<JwtPayload>(token, {
         secret: this.configService.get<string>('JWT_SECRET'),
       });
       request['user'] = payload;

--- a/src/auth/auth.types.ts
+++ b/src/auth/auth.types.ts
@@ -1,0 +1,3 @@
+import { LoginType } from '../user/user.types';
+
+export type JwtPayload = { userNo: number; socialId: string; loginType: LoginType };

--- a/src/auth/auth.user.decorator.ts
+++ b/src/auth/auth.user.decorator.ts
@@ -1,0 +1,6 @@
+import { createParamDecorator } from '@nestjs/common';
+
+export const JwtParam = createParamDecorator((data, req) => {
+  const request = req.switchToHttp().getRequest();
+  return request.user;
+});

--- a/src/user/dto/user.dto.ts
+++ b/src/user/dto/user.dto.ts
@@ -60,7 +60,7 @@ export class signUpPayload {
     example: "Kakao",
     description: "로그인 타입 (Kakao | Apple)"
   })
-  loginType!: string;
+  loginType!: LoginType;
 }
 
 export class SignUpResult extends UserResponse {

--- a/src/user/schema/user.schema.ts
+++ b/src/user/schema/user.schema.ts
@@ -1,11 +1,11 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
+import { LoginType } from '../user.types';
 
 @Schema({ collection: 'user' })
 export class User {
   @Prop()
   userNo!: number;
-
 
   @Prop()
   nickname!: string;
@@ -17,7 +17,7 @@ export class User {
   socialId!: string;
 
   @Prop()
-  loginType!: string;
+  loginType!: LoginType;
 
   @Prop()
   accessToken!: string;

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -10,6 +10,8 @@ import {
   signInPayload,
 } from './dto/user.dto';
 import { AuthGuard } from 'src/auth/auth.guard';
+import { JwtParam } from '../auth/auth.user.decorator';
+import { JwtPayload } from '../auth/auth.types';
 
 @ApiTags('user')
 @Controller('user')

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -9,6 +9,7 @@ import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { LoginType } from './types';
 import { JwtPayload } from '../auth/auth.types';
+import { LoginType } from './user.types';
 
 export type LOGIN_STATE = 'NEED_NICKNAME' | 'NEED_MATCHING' | 'HOME';
 
@@ -26,7 +27,7 @@ export class UserService {
   async signUp({ socialId, loginType }: { socialId: string; loginType: LoginType }) {
     const userNo = await this.autoIncrement('userNo');
     // TODO: accessToken 발급 -> userNo를 넣어서 만들고 singin 할때는 해독해서 userNo 받기?
-    const payload: JwtPayload = { userNo: userNo, socialId: socialId, loginType: LoginType };
+    const payload: JwtPayload = { userNo: userNo, socialId: socialId, loginType: loginType };
     const accessToken = await this.jwtService.signAsync(payload, {
       secret: this.configService.get<string>('JWT_SECRET'),
     });

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -8,6 +8,7 @@ import { UserCounter, UserCounterDocument } from './schema/user-counter.schema';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { LoginType } from './types';
+import { JwtPayload } from '../auth/auth.types';
 
 export type LOGIN_STATE = 'NEED_NICKNAME' | 'NEED_MATCHING' | 'HOME';
 
@@ -25,7 +26,7 @@ export class UserService {
   async signUp({ socialId, loginType }: { socialId: string; loginType: LoginType }) {
     const userNo = await this.autoIncrement('userNo');
     // TODO: accessToken 발급 -> userNo를 넣어서 만들고 singin 할때는 해독해서 userNo 받기?
-    const payload = { userNo: userNo, socialId: socialId, loginType: LoginType };
+    const payload: JwtPayload = { userNo: userNo, socialId: socialId, loginType: LoginType };
     const accessToken = await this.jwtService.signAsync(payload, {
       secret: this.configService.get<string>('JWT_SECRET'),
     });

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -7,6 +7,7 @@ import { User, UserDocument } from './schema/user.schema';
 import { UserCounter, UserCounterDocument } from './schema/user-counter.schema';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
+import { LoginType } from './types';
 
 export type LOGIN_STATE = 'NEED_NICKNAME' | 'NEED_MATCHING' | 'HOME';
 
@@ -21,18 +22,12 @@ export class UserService {
     private configService: ConfigService
   ) {}
 
-  async signUp({
-    socialId,
-    loginType,
-  }: {
-    socialId: string;
-    loginType: string;
-  }) {
+  async signUp({ socialId, loginType }: { socialId: string; loginType: LoginType }) {
     const userNo = await this.autoIncrement('userNo');
     // TODO: accessToken 발급 -> userNo를 넣어서 만들고 singin 할때는 해독해서 userNo 받기?
-    const payload = { userNo: userNo, socialId:socialId, loginType:loginType};
-    const accessToken = await this.jwtService.signAsync(payload,{
-      secret:this.configService.get<string>('JWT_SECRET')
+    const payload = { userNo: userNo, socialId: socialId, loginType: LoginType };
+    const accessToken = await this.jwtService.signAsync(payload, {
+      secret: this.configService.get<string>('JWT_SECRET'),
     });
     console.log(userNo);
     const user = await this.userModel.create({
@@ -158,7 +153,10 @@ export class UserService {
     return result!.count;
   }
 
-  async getUserBySocialIdAndLoginType(socialId: string, loginType: string): Promise<User | null> {
-    return await this.userModel.findOne({socialId: socialId, loginType:loginType});
+  async getUserBySocialIdAndLoginType(
+    socialId: string,
+    loginType: LoginType,
+  ): Promise<User | null> {
+    return await this.userModel.findOne({ socialId: socialId, loginType: loginType });
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -7,7 +7,6 @@ import { User, UserDocument } from './schema/user.schema';
 import { UserCounter, UserCounterDocument } from './schema/user-counter.schema';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
-import { LoginType } from './types';
 import { JwtPayload } from '../auth/auth.types';
 import { LoginType } from './user.types';
 

--- a/src/user/user.types.ts
+++ b/src/user/user.types.ts
@@ -1,0 +1,1 @@
+export type LoginType = 'Kakao' | 'Apple';


### PR DESCRIPTION
## 🔥 관련 이슈
PR 관련해서 수정하면 좋을 것 같아서 수정했어요
https://github.com/mash-up-kr/TwoToo-Node/pull/16

## 🔥 PR Point

- LoginType 타입 분리
- JwtPayload 타입 분리
- JwtParam 커스텀 데코레이터 추가

Controller에서 JwtToken을 해석한 payload 가 필요한 경우 사용하시면 됩니다.
## 🔥 To Reviewers


<img width="720" alt="스크린샷 2023-06-21 오후 3 01 57" src="https://github.com/mash-up-kr/TwoToo-Node/assets/33686751/af1fcc7d-5509-4067-8bda-73265d2e199f">
<img width="308" alt="스크린샷 2023-06-21 오후 3 02 20" src="https://github.com/mash-up-kr/TwoToo-Node/assets/33686751/44dd029b-8205-4ef7-939f-49947422b76f">

UseGaurd 이용해서 Jwt 토큰이 제대로 되어있다는 것을 검증했다면, 엔드포인트 파라미터에서 @JwtParam() 데코레이터를 사용해 JwtPayload 받아서 사용할 수 있어요.
사용하면 깔끔하게 컨트롤러에서 타입추론 할 수 있습니다~