### PR TITLE
feat: histories api 생성

### DIFF
--- a/src/challenge/challenge.controller.ts
+++ b/src/challenge/challenge.controller.ts
@@ -12,6 +12,7 @@ import {
   ChallengeResDto,
   CreateChallenge,
   CreateChallengePayload,
+  ChallengeHistoryResDto,
 } from './dto/challenge.dto';
 
 @ApiTags('challenge')
@@ -21,6 +22,16 @@ export class ChallengeController {
     private readonly userSvc: UserService,
     private readonly challengeSvc: ChallengeService,
   ) {}
+
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard)
+  @Get('histories')
+  @ApiOperation({ description: '히스토리 목록을 조회합니다.', summary: '히스토리 확면 조회' })
+  @ApiResponse({ status: 200, type: [ChallengeHistoryResDto] })
+  async getHistories(@JwtParam() JwtParam: JwtPayload): Promise<ChallengeHistoryResDto[]> {
+    const userNo = JwtParam.userNo;
+    return await this.challengeSvc.getChallengeHistories({ userNo });
+  }
 
   @ApiBearerAuth()
   @UseGuards(AuthGuard)

--- a/src/challenge/challenge.service.ts
+++ b/src/challenge/challenge.service.ts
@@ -7,7 +7,7 @@ import { UserService } from '../user/user.service';
 import { Challenge, ChallengeDocument } from './schema/challenge.schema';
 import { TWOTWO } from '../constants/number';
 import { ChallengeCounter, ChallengeCounterDocument } from './schema/challenge-counter.schema';
-import { ChallengeResDto, CreateChallenge } from './dto/challenge.dto';
+import { ChallengeResDto, CreateChallenge, ChallengeHistoryResDto } from './dto/challenge.dto';
 
 @Injectable()
 export class ChallengeService {
@@ -98,5 +98,32 @@ export class ChallengeService {
     }
 
     return result!.count;
+  }
+
+  async getChallengeHistories({ userNo }: { userNo: number }): Promise<ChallengeHistoryResDto[]> {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0); // 시간을 0으로 설정
+
+    const challenges = await this.challengeModel
+      .find(
+        {
+          $or: [{ 'user1.userNo': userNo }, { 'user2.userNo': userNo }],
+          endDate: { $lt: today },
+        },
+        {
+          _id: 0,
+          name: 1,
+          user1Flower: 1,
+          user2Flower: 1,
+          user1CommitCnt: 1,
+          user2CommitCnt: 1,
+          startDate: 1,
+          endDate: 1,
+        },
+      )
+      .lean()
+      .exec();
+
+    return challenges;
   }
 }

--- a/src/challenge/dto/challenge.dto.ts
+++ b/src/challenge/dto/challenge.dto.ts
@@ -146,3 +146,67 @@ export class CreateChallenge {
   user2Flower: string;
   startDate: Date;
 }
+
+export class ChallengeHistoryResDto {
+  @IsNumber()
+  @IsNotEmpty()
+  @ApiProperty({
+    example: 1,
+    description: '챌린지 번호',
+    required: true,
+  })
+  challengeNo!: number;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    example: '아침 7시 기상',
+    description: '챌린지 이름',
+  })
+  name!: string;
+
+  @IsDate()
+  @IsNotEmpty()
+  @ApiProperty({
+    type: Number,
+    default: new Date(),
+    description: '챌린지 시작일',
+  })
+  startDate!: Date;
+
+  @IsDate()
+  @IsNotEmpty()
+  @ApiProperty({
+    type: Number,
+    default: new Date(new Date().getTime() + 86400000 * 23),
+    description: '챌린지 종료일',
+  })
+  endDate!: Date;
+
+  @IsNumber()
+  @IsNotEmpty()
+  @ApiProperty({
+    example: 10,
+    description: 'user1(생성자) 현재 챌린지의 인증 횟수',
+    required: true,
+  })
+  user1CommitCnt: number;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    example: 'FIG',
+    enum: FlowerType,
+    description: 'user1(생성자)의 꽃',
+  })
+  user1Flower: FlowerType;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    example: 'SUNFLOWER',
+    enum: FlowerType,
+    description: 'user2(생성자)의 꽃',
+  })
+  user2Flower: FlowerType;
+}

--- a/src/challenge/dto/challenge.dto.ts
+++ b/src/challenge/dto/challenge.dto.ts
@@ -192,6 +192,15 @@ export class ChallengeHistoryResDto {
   })
   user1CommitCnt: number;
 
+  @IsNumber()
+  @IsNotEmpty()
+  @ApiProperty({
+    example: 10,
+    description: 'user2(수락자) 현재 챌린지의 인증 횟수',
+    required: true,
+  })
+  user2CommitCnt: number;
+
   @IsString()
   @IsNotEmpty()
   @ApiProperty({


### PR DESCRIPTION
## 🔥 관련 이슈

close #33 

## 🔥 PR Point

- history 리스트뷰 api 생성
- 현재 날짜 이전의 endDate를 가진 챌린지만 불러오기
- 아래와 같은 return값을 가짐
```
[
  {
    "challengeNo": 1,
    "name": "아침 7시 기상",
    "startDate": "2023-07-07T07:08:58.093Z",
    "endDate": "2023-07-30T07:08:58.093Z",
    "user1CommitCnt": 10,
    "user2CommitCnt": 10,
    "user1Flower": "FIG",
    "user2Flower": "SUNFLOWER"
  }
]
```

## 🔥 To Reviewers

