### PR TITLE
Feature/fix-nickname-logic

### DIFF
--- a/src/user/dto/user.dto.ts
+++ b/src/user/dto/user.dto.ts
@@ -143,10 +143,9 @@ export class SetNicknameAndPartnerPayload {
   nickname!: string;
 
   @IsNumber()
-  @ApiProperty({
+  @ApiPropertyOptional({
     example: 2,
     description: '파트너 번호',
-    required: true,
   })
   partnerNo!: number | null;
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -62,16 +62,12 @@ export class UserService {
       throw new BadRequestException('nickname 필드가 필요합니다.');
     }
 
-    if (!_.has(data, 'partnerNo')) {
-      throw new BadRequestException('partnerNo 필드가 필요합니다.');
-    }
-
     if (!_.isNull(user.partnerNo)) {
       throw new ConflictException('현재 유저는 이미 파트너 매칭이 완료되었습니다.');
     }
 
     let updatedUser = null;
-    if (_.isNull(data.partnerNo)) {
+    if (!_.has(data, 'partnerNo')) {
       // 닉네임만 설정하는 경우(초대자)
       updatedUser = await this.userModel.findOneAndUpdate(
         { userNo: userNo },
@@ -82,6 +78,10 @@ export class UserService {
       );
     } else {
       // 닉네임 설정 및 파트너 매칭(초대받은자)
+      if (_.isNull(data.partnerNo)) {
+        throw new BadRequestException('닉네임 설정 및 파트너 매칭에는 파트너 번호가 필요합니다.');
+      }
+
       const partnerUserInfo = await this.getUser(data.partnerNo);
 
       if (_.isNull(partnerUserInfo)) {


### PR DESCRIPTION
## 🔥 관련 이슈

없음

## 🔥 PR Point

- 닉네임만 설정할 때에는 partnerNo 필드를 보내지 않음
- 닉네임 및 파트너 매칭 시에는 partnerNo 필드가 필요하며 이 값은 null일 수 없음
- 클라이언트쪽에서 요청한 내용임

## 🔥 To Reviewers

