### PR TITLE
파트너 매칭 이슈 수정, 내 정보 조회 시 파트너 닉네임, 현재 챌린지 개수 정보 추가

### DIFF
--- a/src/challenge/challenge.service.ts
+++ b/src/challenge/challenge.service.ts
@@ -88,7 +88,6 @@ export class ChallengeService {
     return challengeNo;
   }
 
-
   async finishChallenge(challengeNo: number): Promise<ChallengeDocument> {
     const challenge = await this.challengeModel.findOneAndUpdate(
       { challengeNo },
@@ -99,8 +98,7 @@ export class ChallengeService {
     return challenge;
   }
 
- private async autoIncrement(key: string) {
-
+  private async autoIncrement(key: string) {
     let result: { count: number } | null = null;
 
     while (result === null) {

--- a/src/httpException.filter.ts
+++ b/src/httpException.filter.ts
@@ -9,7 +9,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
     const request = ctx.getRequest<Request>();
     const status = exception.getStatus ? exception.getStatus() : 500;
 
-    const message = exception['response'].message;
+    const message = exception['response'] ? exception['response'].message : exception.message;
     response.status(status).json({
       message: message,
       statusCode: status,

--- a/src/user/dto/user.dto.ts
+++ b/src/user/dto/user.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsOptional } from 'class-validator';
 import { IsString } from 'class-validator';
 import { LOGIN_STATE } from '../user.service';
 import { LoginType } from '../user.types';
@@ -133,6 +133,24 @@ export class UserInfoResDto {
   partnerNo?: number;
 }
 
+export class GetMyInfoResDto extends UserInfoResDto {
+  @IsString()
+  @ApiProperty({
+    example: '왕자',
+    description: '파트너 닉네임',
+    required: true,
+  })
+  partnerNickname!: string | null;
+
+  @IsNumber()
+  @ApiProperty({
+    example: 3,
+    description: '현재까지 진행중인 챌린지 개수',
+    required: true,
+  })
+  totalChallengeCount!: number | 0;
+}
+
 export class SetNicknameAndPartnerPayload {
   @IsString()
   @ApiProperty({
@@ -143,6 +161,7 @@ export class SetNicknameAndPartnerPayload {
   nickname!: string;
 
   @IsNumber()
+  @IsOptional()
   @ApiPropertyOptional({
     example: 2,
     description: '파트너 번호',

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -6,15 +6,23 @@ import { User, UserSchema } from './schema/user.schema';
 import { JwtService } from '@nestjs/jwt';
 import { UserCounter, UserCounterSchema } from './schema/user-counter.schema';
 import { AuthGuard } from 'src/auth/auth.guard';
+import { ChallengeService } from 'src/challenge/challenge.service';
+import { Challenge, ChallengeSchema } from 'src/challenge/schema/challenge.schema';
+import {
+  ChallengeCounter,
+  ChallengeCounterSchema,
+} from 'src/challenge/schema/challenge-counter.schema';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: User.name, schema: UserSchema },
       { name: UserCounter.name, schema: UserCounterSchema },
+      { name: Challenge.name, schema: ChallengeSchema },
+      { name: ChallengeCounter.name, schema: ChallengeCounterSchema },
     ]),
   ],
-  providers: [UserService, AuthGuard, JwtService],
+  providers: [UserService, ChallengeService, AuthGuard, JwtService],
   controllers: [UserController],
   exports: [UserService, AuthGuard, JwtService],
 })

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,4 +1,9 @@
-import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import * as _ from 'lodash';
 import { Model } from 'mongoose';
@@ -25,7 +30,7 @@ export class UserService {
     private readonly userCounterModel: Model<UserCounterDocument>,
     private jwtService: JwtService,
     private configService: ConfigService,
-  ) { }
+  ) {}
 
   async signUp({
     socialId,

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -73,6 +73,9 @@ export class UserService {
         { new: true },
       );
     } else {
+      if (data.partnerNo === userNo) {
+        throw new ConflictException('자기 자신과 파트너 매칭할 수 없습니다.');
+      }
       // 닉네임 설정 및 파트너 매칭(초대받은자)
       if (_.isNull(data.partnerNo)) {
         throw new BadRequestException('닉네임 설정 및 파트너 매칭에는 파트너 번호가 필요합니다.');


### PR DESCRIPTION
## 🔥 관련 이슈

close #61 
close #62 
close #63 

## 🔥 PR Point

61번: 파트너 닉네임 정보(없으면 null), 현재까지 진행한 챌린지 개수(승인된 챌린지 기준) 표시 (기본값 0)
62번: 초대받은 사람이 닉네임 설정 및 파트너 매칭할 때, 초대받은 사람은 매칭하는데, 정작 쌍방 매칭이 안되고 있던 문제 수정
63번: 클라에서 다시 optional로 처리해달라해서 payload쪽만 optional 처리함


## 🔥 To Reviewers

