### PR TITLE
챌린지 그만둘 때, 관련 커밋 모두 삭제 / 순환참조 문제 해결 / 커밋 조회 시 챌린지 번호 조건 추가

### DIFF
--- a/src/challenge/challenge.module.ts
+++ b/src/challenge/challenge.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { ChallengeService } from './challenge.service';
 import { ChallengeController } from './challenge.controller';
 import { MongooseModule } from '@nestjs/mongoose';
@@ -7,10 +7,10 @@ import { UserModule } from '../user/user.module';
 import { ChallengeCounter, ChallengeCounterSchema } from './schema/challenge-counter.schema';
 import { ChallengeValidator } from './challenge.validator';
 
-import { CommitService } from '../commit/commit.service';
 import { Commit, CommitSchema } from '../commit/schema/commit.schema';
 import { CommitCounter, CommitCounterSchema } from '../commit/schema/commit-counter.schema';
 import { User, UserSchema } from 'src/user/schema/user.schema';
+import { CommitModule } from 'src/commit/commit.module';
 
 @Module({
   imports: [
@@ -21,9 +21,10 @@ import { User, UserSchema } from 'src/user/schema/user.schema';
       { name: CommitCounter.name, schema: CommitCounterSchema },
       { name: User.name, schema: UserSchema },
     ]),
-    UserModule,
+    forwardRef(() => UserModule),
+    forwardRef(() => CommitModule)
   ],
-  providers: [ChallengeService, CommitService, ChallengeValidator],
+  providers: [ChallengeService, ChallengeValidator],
   controllers: [ChallengeController],
   exports: [ChallengeService],
 })

--- a/src/challenge/challenge.service.ts
+++ b/src/challenge/challenge.service.ts
@@ -110,7 +110,7 @@ export class ChallengeService {
 
   async deleteChallenge(challengeNo: number): Promise<number> {
     await this.challengeModel.deleteOne({ challengeNo });
-    await this.commitSvc.deleteCommit(challengeNo);
+    await this.commitSvc.deleteCommitWithChallengeNo(challengeNo);
 
     return challengeNo;
   }

--- a/src/challenge/challenge.service.ts
+++ b/src/challenge/challenge.service.ts
@@ -108,6 +108,8 @@ export class ChallengeService {
 
   async deleteChallenge(challengeNo: number): Promise<number> {
     await this.challengeModel.deleteOne({ challengeNo });
+    await this.commitSvc.deleteCommit(challengeNo);
+
     return challengeNo;
   }
 

--- a/src/challenge/challenge.service.ts
+++ b/src/challenge/challenge.service.ts
@@ -14,11 +14,13 @@ import {
   ChallengeHistoryResDto,
   UpdateChallengePayload,
 } from './dto/challenge.dto';
+import { CommitService } from 'src/commit/commit.service';
 
 @Injectable()
 export class ChallengeService {
   constructor(
     private readonly userSvc: UserService,
+    private readonly commitSvc: CommitService,
     @InjectModel(Challenge.name)
     private readonly challengeModel: Model<ChallengeDocument>,
     @InjectModel(ChallengeCounter.name)

--- a/src/commit/commit.module.ts
+++ b/src/commit/commit.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 
 import { CommitService } from './commit.service';
@@ -26,7 +26,7 @@ import { User, UserSchema } from '../user/schema/user.schema';
       useFactory: multerOptionsFactory,
       inject: [ConfigService],
     }),
-    UserModule,
+    forwardRef(() => UserModule),
   ],
   providers: [CommitService, FileService],
   controllers: [CommitController],

--- a/src/commit/commit.service.ts
+++ b/src/commit/commit.service.ts
@@ -156,10 +156,11 @@ export class CommitService {
     return commit;
   }
 
-  async getTodayCommit(userNo: number): Promise<CommitDocument | null> {
+  async getTodayCommit(userNo: number, challengeNo: number): Promise<CommitDocument | null> {
     const commit = await this.commitModel
       .findOne({
         userNo: userNo,
+        challengeNo,
         createdAt: { $gte: startOfToday(), $lte: endOfToday() },
       })
       .sort({ createdAt: -1 })
@@ -189,5 +190,16 @@ export class CommitService {
     });
 
     return result;
+  }
+
+  async deleteCommit(commitNo: number): Promise<CommitDocument> {
+    const deletedCommit = (await this.commitModel.findOneAndDelete({ commitNo })) as CommitDocument;
+    return deletedCommit;
+  }
+
+  async deleteCommitWithChallengeNo(challengeNo: number): Promise<void> {
+    await this.commitModel.deleteMany({ challengeNo });
+
+    return;
   }
 }

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
 import { MongooseModule } from '@nestjs/mongoose';
@@ -6,12 +6,12 @@ import { User, UserSchema } from './schema/user.schema';
 import { JwtService } from '@nestjs/jwt';
 import { UserCounter, UserCounterSchema } from './schema/user-counter.schema';
 import { AuthGuard } from 'src/auth/auth.guard';
-import { ChallengeService } from 'src/challenge/challenge.service';
 import { Challenge, ChallengeSchema } from 'src/challenge/schema/challenge.schema';
 import {
   ChallengeCounter,
   ChallengeCounterSchema,
 } from 'src/challenge/schema/challenge-counter.schema';
+import { ChallengeModule } from 'src/challenge/challenge.module';
 
 @Module({
   imports: [
@@ -21,8 +21,9 @@ import {
       { name: Challenge.name, schema: ChallengeSchema },
       { name: ChallengeCounter.name, schema: ChallengeCounterSchema },
     ]),
+    forwardRef(() => ChallengeModule)
   ],
-  providers: [UserService, ChallengeService, AuthGuard, JwtService],
+  providers: [UserService, AuthGuard, JwtService],
   controllers: [UserController],
   exports: [UserService, AuthGuard, JwtService],
 })

--- a/src/view/homeView.service.ts
+++ b/src/view/homeView.service.ts
@@ -35,8 +35,11 @@ export class HomeViewService {
     let myStingCnt = 0;
 
     if (!_.isNull(recentChallenge)) {
-      myCommit = await this.commitSvc.getTodayCommit(myInfo.userNo);
-      partnerCommit = await this.commitSvc.getTodayCommit(partnerInfo.userNo);
+      myCommit = await this.commitSvc.getTodayCommit(myInfo.userNo, recentChallenge.challengeNo);
+      partnerCommit = await this.commitSvc.getTodayCommit(
+        partnerInfo.userNo,
+        recentChallenge.challengeNo,
+      );
       myStingCnt = await this.notificationSvc.getStingCount(userNo);
     }
 


### PR DESCRIPTION
## 🔥 PR Point

- 챌린지 그만둘때 챌린지번호의 모든 커밋 삭제
- 순환참조 문제 해결
- 오늘 커밋 조회 시 챌린지 번호 정보도 추가