### PR TITLE
파트너가 챌린지를 생성한 상태에서 본인이 챌린지 중복 생성 시, 기존 챌린지 삭제 후 새로 만들도록 수정

### DIFF
--- a/src/challenge/challenge.controller.ts
+++ b/src/challenge/challenge.controller.ts
@@ -53,7 +53,7 @@ export class ChallengeController {
     const challengeInfo: CreateChallenge = {
       name: data.name,
       description: data.description,
-      user1No: user.userNo,
+      user1: user,
       user2Flower: data.user2Flower,
       startDate: new Date(data.startDate),
     };

--- a/src/challenge/challenge.module.ts
+++ b/src/challenge/challenge.module.ts
@@ -22,7 +22,7 @@ import { CommitModule } from 'src/commit/commit.module';
       { name: User.name, schema: UserSchema },
     ]),
     forwardRef(() => UserModule),
-    forwardRef(() => CommitModule)
+    forwardRef(() => CommitModule),
   ],
   providers: [ChallengeService, ChallengeValidator],
   controllers: [ChallengeController],

--- a/src/challenge/challenge.service.ts
+++ b/src/challenge/challenge.service.ts
@@ -85,6 +85,7 @@ export class ChallengeService {
     const challenge = await this.challengeModel
       .findOne({
         $or: [{ 'user1.userNo': userNo }, { 'user2.userNo': userNo }],
+        isDeleted: false
       })
       .sort({ challengeNo: -1 });
     return challenge;

--- a/src/challenge/challenge.service.ts
+++ b/src/challenge/challenge.service.ts
@@ -36,20 +36,23 @@ export class ChallengeService {
 
     // user2: 챌린지 수락할 자
     const user2 = await this.userSvc.getUser(user1.partnerNo as number);
-    
+
     try {
       // 파트너가 이미 생성한 챌린지가 있는지 확인
       // [챌린지 찾는 조건]
       // isApproved: false - 아직 수락 안됨
       // user1.userNo === user1.partnerNo - 생성자(user1).userNo === 현재 요청자의 파트너(user1).partnerNo
-      const existingChallenge = await this.challengeModel.findOne({ isApproved: false, "user1.userNo": user1.partnerNo })
+      const existingChallenge = await this.challengeModel.findOne({
+        isApproved: false,
+        'user1.userNo': user1.partnerNo,
+      });
 
       // 이미 생성된 챌린지가 있는 경우 삭제 후 생성
       if (existingChallenge) {
         await this.deleteChallenge(existingChallenge.challengeNo);
       }
 
-      const endDate: Date = add(endOfDay(challengeInfo.startDate), { days: 21 });  
+      const endDate: Date = add(endOfDay(challengeInfo.startDate), { days: 21 });
       const challengeNo = await this.autoIncrement('challengeNo');
 
       const challenge = await this.challengeModel.create({
@@ -62,7 +65,7 @@ export class ChallengeService {
         endDate: endDate,
         user2Flower: challengeInfo.user2Flower,
       });
-  
+
       await challenge.save();
       return challenge;
     } catch (err) {
@@ -102,7 +105,7 @@ export class ChallengeService {
   async findRecentChallenge(userNo: number): Promise<ChallengeDocument | null> {
     const challenge = await this.challengeModel
       .findOne({
-        $or: [{ 'user1.userNo': userNo }, { 'user2.userNo': userNo }]
+        $or: [{ 'user1.userNo': userNo }, { 'user2.userNo': userNo }],
       })
       .sort({ challengeNo: -1 });
     return challenge;

--- a/src/challenge/challenge.service.ts
+++ b/src/challenge/challenge.service.ts
@@ -41,9 +41,8 @@ export class ChallengeService {
       // 파트너가 이미 생성한 챌린지가 있는지 확인
       // [챌린지 찾는 조건]
       // isApproved: false - 아직 수락 안됨
-      // isDeleted: false - 삭제되지 않은 챌린지
       // user1.userNo === user1.partnerNo - 생성자(user1).userNo === 현재 요청자의 파트너(user1).partnerNo
-      const existingChallenge = await this.challengeModel.findOne({ isApproved: false, isDeleted: false, "user1.userNo": user1.partnerNo })
+      const existingChallenge = await this.challengeModel.findOne({ isApproved: false, "user1.userNo": user1.partnerNo })
 
       // 이미 생성된 챌린지가 있는 경우 삭제 후 생성
       if (existingChallenge) {
@@ -103,8 +102,7 @@ export class ChallengeService {
   async findRecentChallenge(userNo: number): Promise<ChallengeDocument | null> {
     const challenge = await this.challengeModel
       .findOne({
-        $or: [{ 'user1.userNo': userNo }, { 'user2.userNo': userNo }],
-        isDeleted: false
+        $or: [{ 'user1.userNo': userNo }, { 'user2.userNo': userNo }]
       })
       .sort({ challengeNo: -1 });
     return challenge;

--- a/src/challenge/challenge.service.ts
+++ b/src/challenge/challenge.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { add, endOfDay } from 'date-fns';
@@ -27,30 +27,49 @@ export class ChallengeService {
   ) {}
 
   async createChallenge(challengeInfo: CreateChallenge): Promise<ChallengeResDto> {
-    const user1 = await this.userSvc.getUser(challengeInfo.user1No);
+    // user1: 챌린지 생성 요청을 보낸 자
+    const user1 = challengeInfo.user1;
 
     if (_.isNull(user1.partnerNo)) {
       throw new NotFoundException('파트너가 존재하지 않습니다');
     }
 
+    // user2: 챌린지 수락할 자
     const user2 = await this.userSvc.getUser(user1.partnerNo as number);
+    
+    try {
+      // 파트너가 이미 생성한 챌린지가 있는지 확인
+      // [챌린지 찾는 조건]
+      // isApproved: false - 아직 수락 안됨
+      // isDeleted: false - 삭제되지 않은 챌린지
+      // user1.userNo === user1.partnerNo - 생성자(user1).userNo === 현재 요청자의 파트너(user1).partnerNo
+      const existingChallenge = await this.challengeModel.findOne({ isApproved: false, isDeleted: false, "user1.userNo": user1.partnerNo })
 
-    const endDate: Date = add(endOfDay(challengeInfo.startDate), { days: 21 });
+      // 이미 생성된 챌린지가 있는 경우 삭제 후 생성
+      if (existingChallenge) {
+        await this.deleteChallenge(existingChallenge.challengeNo);
+      }
 
-    const challengeNo = await this.autoIncrement('challengeNo');
-    const challenge = await this.challengeModel.create({
-      challengeNo,
-      name: challengeInfo.name,
-      description: challengeInfo.description,
-      user1: this.userSvc.getPartialUserInfo(user1),
-      user2: this.userSvc.getPartialUserInfo(user2),
-      startDate: challengeInfo.startDate,
-      endDate: endDate,
-      user2Flower: challengeInfo.user2Flower,
-    });
+      const endDate: Date = add(endOfDay(challengeInfo.startDate), { days: 21 });  
+      const challengeNo = await this.autoIncrement('challengeNo');
 
-    await challenge.save();
-    return challenge;
+      const challenge = await this.challengeModel.create({
+        challengeNo,
+        name: challengeInfo.name,
+        description: challengeInfo.description,
+        user1: this.userSvc.getPartialUserInfo(user1),
+        user2: this.userSvc.getPartialUserInfo(user2),
+        startDate: challengeInfo.startDate,
+        endDate: endDate,
+        user2Flower: challengeInfo.user2Flower,
+      });
+  
+      await challenge.save();
+      return challenge;
+    } catch (err) {
+      // TODO: error handling for mongodb
+      throw new BadRequestException('챌린지 생성에 실패했습니다.');
+    }
   }
 
   async findChallenge(challengeNo: number): Promise<ChallengeDocument> {

--- a/src/challenge/challenge.service.ts
+++ b/src/challenge/challenge.service.ts
@@ -41,10 +41,10 @@ export class ChallengeService {
       // 파트너가 이미 생성한 챌린지가 있는지 확인
       // [챌린지 찾는 조건]
       // isApproved: false - 아직 수락 안됨
-      // user1.userNo === user1.partnerNo - 생성자(user1).userNo === 현재 요청자의 파트너(user1).partnerNo
+      // user1.userNo === user1.partnerNo - 생성자(user1).userNo === 현재 요청자의 파트너(user2).userNo
       const existingChallenge = await this.challengeModel.findOne({
         isApproved: false,
-        'user1.userNo': user1.partnerNo,
+        'user1.userNo': user2.userNo,
       });
 
       // 이미 생성된 챌린지가 있는 경우 삭제 후 생성

--- a/src/challenge/dto/challenge.dto.ts
+++ b/src/challenge/dto/challenge.dto.ts
@@ -11,6 +11,7 @@ import {
 } from 'class-validator';
 import { UserInfoResDto } from '../../user/dto/user.dto';
 import { CommitResDto } from 'src/commit/dto/commit.dto';
+import { User } from 'src/user/schema/user.schema';
 
 export enum FlowerType {
   FIG = 'FIG',
@@ -210,7 +211,7 @@ export class AcceptChallengePayload {
 export class CreateChallenge {
   name: string;
   description: string;
-  user1No: number;
+  user1: User;
   user2Flower: string;
   startDate: Date;
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -53,7 +53,7 @@ export class UserController {
     }
     user = await this.userSvc.signUp({ socialId, loginType, deviceToken });
     if (_.isNull(user)) {
-    throw new BadRequestException('유저 생성에 실패했습니다.');
+      throw new BadRequestException('유저 생성에 실패했습니다.');
     }
 
     return {

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -21,7 +21,7 @@ import { ChallengeModule } from 'src/challenge/challenge.module';
       { name: Challenge.name, schema: ChallengeSchema },
       { name: ChallengeCounter.name, schema: ChallengeCounterSchema },
     ]),
-    forwardRef(() => ChallengeModule)
+    forwardRef(() => ChallengeModule),
   ],
   providers: [UserService, AuthGuard, JwtService],
   controllers: [UserController],


### PR DESCRIPTION
## 🔥 관련 이슈

close #73

## 🔥 PR Point

논의한대로 기존 챌린지를 삭제하고, 새로 만들도록 수정합니다.
- mongodb error는 mongo exception filter를 만들어야하는데 그럴 시간이 없어서 일단 BadRequestException으로 핸들링함
- 챌린지 생성 시, 요청자의 userNo만 받도록 되어있는데, 요청자의 모든 정보를 받아서 내 파트너 번호도 쉽게 가져올 수 있도록 수정
- 파트너가 생성한 챌린지가 있는지 확인
  - `findRecentChallenge`를 사용해서 isApproved 필드를 확인해도 되지만, 그냥 findOneAndUpdate 쿼리를 사용하여 조건에 맞는 도큐먼트 찾도록 구현
- 있을 경우 삭제하도록 변경 (클라이언트에서 수락 여부 확인하는 API가 home view여서 기존 challengeNo 정보가 필요 없음)

## 🔥 To Reviewers
- 일단 생각대로 코드 작성했는데 리뷰 좀 부탁드립니다아
