### PR TITLE
유저 삭제 로직  추가, 파트너도 같이 삭제

### DIFF
--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -152,19 +152,20 @@ export class UserController {
   @UseGuards(AuthGuard)
   @Delete('/signOut')
   @ApiOperation({
-    description: '유저를 탈퇴 합니다. 파트너도 같이 삭제 됩니디.',
+    description: '유저를 탈퇴 합니다. 파트너도 같이 삭제 됩니다.',
     summary: '유저 탈퇴',
   })
   @ApiResponse({ status: 200, type: Boolean })
   async signOut(@JwtParam() jwtParam: JwtPayload): Promise<Boolean> {
     const { userNo } = jwtParam;
     const user = await this.userSvc.getUser(userNo);
+    let partenrRet = true;
 
     if (user.partnerNo) {
-      this.userSvc.delUser(user.partnerNo);
+      partenrRet = await this.userSvc.delUser(user.partnerNo);
     }
-    this.userSvc.delUser(userNo);
+    const ret = await this.userSvc.delUser(userNo);
 
-    return true;
+    return ret && partenrRet;
   }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,4 +1,14 @@
-import { BadRequestException, Body, Controller, Get, Patch, Post, UseGuards } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  NotFoundException,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import * as _ from 'lodash';
 import {
@@ -136,5 +146,25 @@ export class UserController {
       partnerNickname: partnerNickname,
       totalChallengeCount,
     };
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard)
+  @Delete('/signOut')
+  @ApiOperation({
+    description: '유저를 탈퇴 합니다. 파트너도 같이 삭제 됩니디.',
+    summary: '유저 탈퇴',
+  })
+  @ApiResponse({ status: 200, type: Boolean })
+  async signOut(@JwtParam() jwtParam: JwtPayload): Promise<Boolean> {
+    const { userNo } = jwtParam;
+    const user = await this.userSvc.getUser(userNo);
+
+    if (user.partnerNo) {
+      this.userSvc.delUser(user.partnerNo);
+    }
+    this.userSvc.delUser(userNo);
+
+    return true;
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -220,9 +220,13 @@ export class UserService {
     return { userNo, nickname, partnerNo };
   }
 
-  async delUser(userNo: Number) {
-    await this.userModel.deleteOne({
+  async delUser(userNo: Number): Promise<boolean> {
+    const user = await this.userModel.findOneAndDelete({
       userNo: userNo,
     });
+    if (_.isNull(user)) {
+      throw new NotFoundException(`${userNo}의 삭제에 실패했습니다.`);
+    }
+    return true;
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -219,4 +219,10 @@ export class UserService {
 
     return { userNo, nickname, partnerNo };
   }
+
+  async delUser(userNo: Number) {
+    await this.userModel.deleteOne({
+      userNo: userNo,
+    });
+  }
 }


### PR DESCRIPTION
## 🔥 관련 이슈

close #75

## 🔥 PR Point

- 유저 삭제
- 파트너 정보도 같이 삭제
- return은 boolen 성공하면 true 실패(유저 존재 하지 않으면 에러 반환)

## 🔥 To Reviewers

