### PR TITLE
delPartner 생성

### DIFF
--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -137,4 +137,20 @@ export class UserController {
       totalChallengeCount,
     };
   }
+
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard)
+  @Patch('/delPartner')
+  @ApiOperation({
+    description: '파트너와 매칭을 해제합니다. 닉네임 설정부터 다시하게 합니다. 파트너도 동일',
+    summary: '파트너 매칭 해제',
+  })
+  @ApiResponse({ status: 200, type: Boolean })
+  async delPartner(@JwtParam() jwtParam: JwtPayload): Promise<Boolean> {
+    const { userNo } = jwtParam;
+    const user = await this.userSvc.getUser(userNo);
+
+    const ret = await this.userSvc.delPartenr(user);
+    return ret;
+  }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -14,6 +14,7 @@ import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { JwtPayload } from '../auth/auth.types';
 import { LoginType } from './user.types';
+import { ChallengeDocument } from 'dist/challenge/schema/challenge.schema';
 
 export enum LOGIN_STATE {
   NEED_NICKNAME = 'NEED_NICKNAME',
@@ -30,6 +31,7 @@ export class UserService {
     private readonly userCounterModel: Model<UserCounterDocument>,
     private jwtService: JwtService,
     private configService: ConfigService,
+    private challengeModel: Model<ChallengeDocument>,
   ) {}
 
   async signUp({
@@ -218,5 +220,29 @@ export class UserService {
     const { userNo, nickname, partnerNo } = user;
 
     return { userNo, nickname, partnerNo };
+  }
+
+  async delPartenr(user: User) {
+    const partnerNo = user.partnerNo;
+
+    if (partnerNo === null) {
+      throw new NotFoundException('파트너가 존재하지 않습니다.');
+    }
+    try {
+      await this.userModel.updateMany(
+        {
+          userNo: { $in: [user.userNo, user.partnerNo] },
+        },
+        { nickname: null, partnerNo: null },
+      );
+
+      await this.challengeModel.deleteMany({
+        $or: [{ 'user1.userNo': user.userNo }, { 'user2.userNo': user.userNo }],
+      });
+    } catch (e) {
+      console.log(e);
+    }
+
+    return true;
   }
 }


### PR DESCRIPTION
## 🔥 관련 이슈

close #76 

## 🔥 PR Point

- 유저 파트너 해지시 유저 정보에서 partnerNo, nickname 삭제
- 유저는 nickname설정 페이지로 이동
- 해당유저의 모든 챌린지도 삭제

## 🔥 To Reviewers

