### PR TITLE
fix: notification 추가/삭제 시에 challengeNo 연관관계 추가

### DIFF
--- a/src/notification/notification.module.ts
+++ b/src/notification/notification.module.ts
@@ -8,6 +8,7 @@ import { JwtService } from '@nestjs/jwt';
 import { User, UserSchema } from 'src/user/schema/user.schema';
 import { UserCounter, UserCounterSchema } from 'src/user/schema/user-counter.schema';
 import { UserModule } from '../user/user.module';
+import { ChallengeModule } from '../challenge/challenge.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { UserModule } from '../user/user.module';
       { name: UserCounter.name, schema: UserCounterSchema },
     ]),
     UserModule,
+    ChallengeModule,
   ],
   controllers: [NotificationController],
   providers: [NotificationService, AuthGuard, JwtService],

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -17,7 +17,8 @@ export class NotificationService {
   ) {}
   async getStingCount(userNo: number): Promise<number> {
     const recentChallenge = await this.challengeService.findRecentChallenge(userNo);
-    if (recentChallenge == null) throw new NotFoundException('챌린지가 존재하지 않습니다.');
+    if (recentChallenge == null || recentChallenge.isDeleted)
+      throw new NotFoundException('챌린지가 존재하지 않습니다.');
 
     const ret = await this.notificaitonModel
       .findOne({

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import * as FirebaseAdmin from 'firebase-admin';
@@ -6,17 +6,23 @@ import * as FirebaseAdmin from 'firebase-admin';
 import { PushResDto } from './dto/notification.dto';
 import { Notification, NotificationDocument } from './schema/notification.schema';
 import { endOfToday, startOfToday } from 'date-fns';
+import { ChallengeService } from '../challenge/challenge.service';
 
 @Injectable()
 export class NotificationService {
   constructor(
     @InjectModel(Notification.name)
     private readonly notificaitonModel: Model<NotificationDocument>,
+    private readonly challengeService: ChallengeService,
   ) {}
   async getStingCount(userNo: number): Promise<number> {
+    const recentChallenge = await this.challengeService.findRecentChallenge(userNo);
+    if (recentChallenge == null) throw new NotFoundException('챌린지가 존재하지 않습니다.');
+
     const ret = await this.notificaitonModel
       .findOne({
         userNo: userNo,
+        challengeNo: recentChallenge.challengeNo,
         createdAt: { $gte: startOfToday(), $lte: endOfToday() },
       })
       .count();
@@ -65,7 +71,11 @@ export class NotificationService {
     message: string;
     userNo: number;
   }): Promise<Notification> {
+    const recentChallenge = await this.challengeService.findRecentChallenge(userNo);
+    if (recentChallenge == null) throw new BadRequestException('챌린지가 존재하지 않습니다.');
+
     const notification = await this.notificaitonModel.create({
+      challengeNo: recentChallenge.challengeNo,
       message: message,
       userNo: userNo,
     });

--- a/src/notification/schema/notification.schema.ts
+++ b/src/notification/schema/notification.schema.ts
@@ -9,6 +9,9 @@ export class Notification {
   userNo!: number;
 
   @Prop()
+  challengeNo!: number;
+
+  @Prop()
   createdAt: Date;
 
   @Prop()


### PR DESCRIPTION
## 🔥 관련 이슈

close https://github.com/mash-up-kr/TwoToo-Node/issues/82

## 🔥 PR Point
- notification에 challengeNo 추가
- notification 추가/삭제시 challengeNo 관련 로직 추가

## 🔥 To Reviewers

