### PR TITLE
오늘 성장일지 실패로 보이는 문제 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "",
   "license": "MIT",
   "scripts": {
-    "build": "nest build --webpack && sed -i 's/exports.handler = handler;/module.exports.handler = handler;/g' dist/lambda.js",
+    "build": "nest build",
     "build:mac": "nest build --webpack && sed -i '' 's~exports.handler = handler;~module.exports.handler = handler;~g' dist/lambda.js",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",

--- a/src/challenge/challenge.service.ts
+++ b/src/challenge/challenge.service.ts
@@ -270,7 +270,7 @@ export class ChallengeService {
     const startDateUTC = startOfDay(startDate); // XXXX-XX-XXT15:00:00.000Z
     const endDateUTC = endOfDay(addDays(startDate, 21)); // XXXX-XX-XXT14:59:59.999Z - 챌린지 시작일로부터 21일 뒤 (시작일포함 22일치)
     const now = new Date();
-
+    const nowStartOfDay = startOfDay(now);
     const growthList: GrowthDiaryState[] = [];
     let isCommittedTodayOrYesterday = false;
 
@@ -283,6 +283,9 @@ export class ChallengeService {
       if (isBefore(d, now)) {
         const isCommitExist = commitList.some(c => isAfter(c.createdAt, d) && isBefore(c.createdAt, endTime));
         status = isCommitExist ? GrowthDiaryState.SUCCESS : GrowthDiaryState.FAIL;
+        if (nowStartOfDay === d && status === GrowthDiaryState.FAIL) {
+          status = GrowthDiaryState.NOT_COMMIT;
+        }
 
         // 어제 시작일 ~ 현재까지 커밋 여부 확인
         isCommittedTodayOrYesterday = commitList.some(c => isAfter(c.createdAt, startOfDay(addDays(now, -1))) && isBefore(c.createdAt, endOfDay(now)));


### PR DESCRIPTION

## 🔥 PR Point

- 오늘 성장일지 실패로 보이는 문제 해결
- 성공 실패는 오늘까지 모두 비교하고 성공 || 실패로 넣고 있었음
- 이 때문에 오늘 인증을 안하면 실패 성공하면 성공으로 보이고 있었음
- 만약 오늘 && 인증 실패 라면 notCOmmit으로 보이게 설정

